### PR TITLE
Add Support for Making Proc calls with TVPs as RPC Call

### DIFF
--- a/SqlReplay.Console/CustomPreProcessor/CustomPreProcessor.cs
+++ b/SqlReplay.Console/CustomPreProcessor/CustomPreProcessor.cs
@@ -37,9 +37,6 @@ namespace SqlReplay.Console.CustomPreProcessing
             // Create Session, with RPC Event
             GenerateSessions();
 
-            // Determine max string length of EventSequence to allow "numerical" OrderBy sorting below
-            int maxSequenceLength = sessions.Values.Max(x => x.Events[0].EventSequence.Length);
-
             /* If a future update to this custom implementation allows for multiple events per session,
                uncomment the block below to ensure the events are sorted numerically in ascending fashion.
             */
@@ -51,7 +48,7 @@ namespace SqlReplay.Console.CustomPreProcessing
 
             var run = new Run()
             {
-                Sessions = sessions.Values.Where(s => s.Events.Count > 0).OrderBy(s => s.Events.First().EventSequence.PadLeft(maxSequenceLength, '0')).ToList()
+                Sessions = sessions.Values.Where(s => s.Events.Count > 0).OrderBy(s => s.Events.First().EventSequence).ToList()
             };
 
             run.EventCaptureOrigin = run.Sessions.First().Events.First().Timestamp;
@@ -64,7 +61,7 @@ namespace SqlReplay.Console.CustomPreProcessing
             sessions = new ConcurrentDictionary<string, Session>();
             var timeStamp = startDateTime;
 
-            int sessionCount = 1;
+            long sessionCount = 1;
             while (sessionCount <= totalSessions)
             {
                 var session_id = sessionCount.ToString();
@@ -77,13 +74,13 @@ namespace SqlReplay.Console.CustomPreProcessing
             }
         }
 
-        private Event GetEvent(int sequence, DateTimeOffset timeStamp)
+        private Event GetEvent(long sequence, DateTimeOffset timeStamp)
         {
             Event evt = null;
 
             evt = new Rpc()
             {
-                EventSequence = sequence.ToString(),
+                EventSequence = sequence,
                 TransactionId = "0", // Always 0 for now
                 Procedure = storedProcedureName,
                 Statement = null,

--- a/SqlReplay.Console/CustomPreProcessor/ParameterLoader.cs
+++ b/SqlReplay.Console/CustomPreProcessor/ParameterLoader.cs
@@ -28,7 +28,7 @@ namespace SqlReplay.Console.CustomPreProcessing
             Parameter p = new Parameter
             {
                 Name = parameterInfo.parameterName,
-                DbType = (SqlDbType)Enum.Parse(typeof(SqlDbType), parameterInfo.parameterProperties["DBType"].ToString(), true),
+                SqlDbType = (SqlDbType)Enum.Parse(typeof(SqlDbType), parameterInfo.parameterProperties["DBType"].ToString(), true),
                 Size = int.Parse(parameterInfo.parameterProperties["Size"].ToString()),
                 Precision = byte.Parse(parameterInfo.parameterProperties["Precision"].ToString()),
                 Scale = byte.Parse(parameterInfo.parameterProperties["Scale"].ToString()),

--- a/SqlReplay.Console/Event.cs
+++ b/SqlReplay.Console/Event.cs
@@ -5,7 +5,7 @@
     [Serializable]
     public abstract class Event
     {
-        public string EventSequence { get; set; }
+        public long EventSequence { get; set; }
         public string TransactionId { get; set; }        
         public DateTimeOffset Timestamp { get; set; }
     }

--- a/SqlReplay.Console/EventExecutor.cs
+++ b/SqlReplay.Console/EventExecutor.cs
@@ -245,7 +245,7 @@
                     Scale = param.Scale,
                     Direction = param.Direction
                 };
-                if (param.SqlDbType == SqlDbType.Structured)
+                if (param.SqlDbType == SqlDbType.Structured && param.Value != DBNull.Value)
                 {
                     var userType = (UserType)param.Value;
                     if (userType.Rows.Count > 0)
@@ -281,10 +281,12 @@
                                     case SqlDbType.Date:
                                     case SqlDbType.Time:
                                     case SqlDbType.DateTime2:
-                                        sqlDataRecord.SetValue(i, DateTime.Parse(row[i].ToString()));
+                                        DateTime.TryParse(row[i].ToString(), out var dateTime);
+                                        sqlDataRecord.SetValue(i, dateTime);
                                         break;
                                     case SqlDbType.DateTimeOffset:
-                                        sqlDataRecord.SetValue(i, DateTimeOffset.Parse(row[i].ToString()));
+                                        DateTimeOffset.TryParse(row[i].ToString(), out var dateTimeOffset);
+                                        sqlDataRecord.SetValue(i, dateTimeOffset);
                                         break;
                                     default:
                                         sqlDataRecord.SetValue(i, row[i]);

--- a/SqlReplay.Console/EventExecutor.cs
+++ b/SqlReplay.Console/EventExecutor.cs
@@ -6,6 +6,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Data;
+    using Microsoft.SqlServer.Server;
 
     public class EventExecutor
     {       
@@ -95,26 +96,14 @@
                                                 {
                                                     commandText = rpc.Statement;
                                                     commandType = CommandType.Text;
-                                                }                                                                                          
+                                                }
                                                 using (var cmd = new SqlCommand(commandText, dbTrx.Connection, dbTrx)
                                                 {
                                                     CommandType = commandType,
                                                     CommandTimeout = 1800
                                                 })
                                                 {
-                                                    foreach (var param in rpc.Parameters)
-                                                    {
-                                                        cmd.Parameters.Add(new SqlParameter
-                                                        {
-                                                            ParameterName = param.Name,
-                                                            SqlDbType = param.DbType,
-                                                            Size = param.Size,
-                                                            Precision = param.Precision,
-                                                            Scale = param.Scale,
-                                                            Direction = param.Direction,
-                                                            Value = param.Value
-                                                        });
-                                                    }
+                                                    SetupSqlCommandParameters(cmd, rpc);
                                                     try
                                                     {
                                                         cmd.ExecuteNonQuery();
@@ -136,9 +125,9 @@
                             finally
                             {
                                 con?.Close();
-                                con?.Dispose();                                
+                                con?.Dispose();
                             }
-                        }                        
+                        }
                     }
                     else if (evt is Rpc rpc)
                     {
@@ -163,19 +152,7 @@
                                 CommandTimeout = 1800
                             })
                             {
-                                foreach (var param in rpc.Parameters)
-                                {
-                                    cmd.Parameters.Add(new SqlParameter
-                                    {
-                                        ParameterName = param.Name,
-                                        SqlDbType = param.DbType,
-                                        Size = param.Size,
-                                        Precision = param.Precision,
-                                        Scale = param.Scale,
-                                        Direction = param.Direction,
-                                        Value = param.Value
-                                    });
-                                }
+                                SetupSqlCommandParameters(cmd, rpc);
                                 try
                                 {
                                     await cmd.ExecuteNonQueryAsync();
@@ -186,7 +163,7 @@
                                 }
                             }
                             con.Close();
-                        }                                                  
+                        }
                     }
                     else if (evt is BulkInsert bulk)
                     {
@@ -197,7 +174,7 @@
                         }
 
                         for (int i = 0; i < bulk.Rows; ++i)
-                        {                         
+                        {
                             dataTable.Rows.Add(dataTable.NewRow());
                         }
 
@@ -213,12 +190,12 @@
                                     foreach (DataColumn column in dataTable.Columns)
                                     {
                                         bulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping(column.ColumnName, column.ColumnName));
-                                    }                                
-                                                                   
-                                        await bulkCopy.WriteToServerAsync(dataTable);                                        
                                     }
-                                
+
+                                    await bulkCopy.WriteToServerAsync(dataTable);
                                 }
+
+                            }
                             catch (Exception ex)
                             {
                                 this.Exceptions.Add(ex);
@@ -228,7 +205,7 @@
                     }
                 }));
             }
-            await Task.WhenAll(tasks);            
+            await Task.WhenAll(tasks);
             Console.WriteLine("Ending bucket: " + events.First().Timestamp);
         }
 
@@ -253,6 +230,79 @@
                 }
             }
             return con;
+        }
+
+        private void SetupSqlCommandParameters(SqlCommand cmd, Rpc rpc)
+        {
+            foreach (var param in rpc.Parameters)
+            {
+                var sqlParam = new SqlParameter
+                {
+                    ParameterName = param.Name,
+                    SqlDbType = param.SqlDbType,
+                    Size = param.Size,
+                    Precision = param.Precision,
+                    Scale = param.Scale,
+                    Direction = param.Direction
+                };
+                if (param.SqlDbType == SqlDbType.Structured)
+                {
+                    var userType = (UserType)param.Value;
+                    if (userType.Rows.Count > 0)
+                    {
+                        var sqlMetaData = new SqlMetaData[userType.Columns.Count];
+                        for (var i = 0; i < userType.Columns.Count; i++)
+                        {
+                            var col = userType.Columns[i];
+                            switch (col.SqlDbType)
+                            {
+                                case SqlDbType.Char:                                                                
+                                case SqlDbType.NChar:
+                                case SqlDbType.NVarChar:
+                                case SqlDbType.VarChar:                                    
+                                    sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType, col.Size);
+                                    break;
+                                default:
+                                    sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType);
+                                    break;
+                            }
+                        }
+
+                        var tvpValue = new List<SqlDataRecord>();
+                        foreach (var row in userType.Rows)
+                        {
+                            var sqlDataRecord = new SqlDataRecord(sqlMetaData);
+                            for (var i = 0; i < sqlMetaData.Length; i++)
+                            {
+                                switch (sqlMetaData[i].SqlDbType)
+                                {
+                                    case SqlDbType.SmallDateTime:
+                                    case SqlDbType.DateTime:
+                                    case SqlDbType.Date:
+                                    case SqlDbType.Time:
+                                    case SqlDbType.DateTime2:
+                                        sqlDataRecord.SetValue(i, DateTime.Parse(row[i].ToString()));
+                                        break;
+                                    case SqlDbType.DateTimeOffset:
+                                        sqlDataRecord.SetValue(i, DateTimeOffset.Parse(row[i].ToString()));
+                                        break;
+                                    default:
+                                        sqlDataRecord.SetValue(i, row[i]);
+                                        break;
+                                }
+                            }
+                            tvpValue.Add(sqlDataRecord);
+                        }
+                        sqlParam.Value = tvpValue;
+                    }                    
+                    sqlParam.TypeName = param.TypeName;
+                }
+                else
+                {
+                    sqlParam.Value = param.Value;
+                }
+                cmd.Parameters.Add(sqlParam);
+            }
         }
 
         private DataColumn GetDataColumn(Column column)

--- a/SqlReplay.Console/Parameter.cs
+++ b/SqlReplay.Console/Parameter.cs
@@ -7,11 +7,13 @@
     public class Parameter
     {
         public string Name { get; set; }
-        public SqlDbType DbType { get; set; }
+        public SqlDbType SqlDbType { get; set; }        
         public int Size { get; set; }
         public byte Precision { get; set; }
         public byte Scale { get; set; }
         public ParameterDirection Direction { get; set; }
+        public string TypeName { get; set; }
+        public int? UserTypeId { get; set; }
         public object Value { get; set; }
     }
 }

--- a/SqlReplay.Console/PreProcessor.cs
+++ b/SqlReplay.Console/PreProcessor.cs
@@ -46,7 +46,7 @@
                         {
                             evt = new Rpc()
                             {
-                                EventSequence = xevent.Actions["event_sequence"].ToString(),
+                                EventSequence = long.Parse(xevent.Actions["event_sequence"].ToString()),
                                 TransactionId = xevent.Actions["transaction_id"].ToString(),
                                 Statement = xevent.Fields["statement"].ToString(),
                                 ObjectName = xevent.Fields["object_name"].ToString(),
@@ -61,7 +61,7 @@
                             {
                                 evt = new Transaction()
                                 {
-                                    EventSequence = xevent.Actions["event_sequence"].ToString(),
+                                    EventSequence = long.Parse(xevent.Actions["event_sequence"].ToString()),
                                     TransactionId = xevent.Fields["transaction_id"].ToString(),
                                     TransactionState = xevent.Fields["transaction_state"].ToString(),
                                     Timestamp = xevent.Timestamp
@@ -73,7 +73,7 @@
                         {
                             var bulkInsert = new BulkInsert()
                             {
-                                EventSequence = xevent.Actions["event_sequence"].ToString(),
+                                EventSequence = long.Parse(xevent.Actions["event_sequence"].ToString()),
                                 TransactionId = xevent.Actions["transaction_id"].ToString(),
                                 BatchText = xevent.Fields["batch_text"].ToString(),
                                 Timestamp = xevent.Timestamp

--- a/SqlReplay.Console/PreProcessor.cs
+++ b/SqlReplay.Console/PreProcessor.cs
@@ -286,7 +286,7 @@
                                 select [Name]=c.[name], [Type]=type_name(c.system_type_id), [Length]=c.max_length
                                 from sys.table_types tt
                                 join sys.columns c on c.object_id = tt.type_table_object_id
-                                where tt.user_type_id = @userTypeId
+                                where tt.user_type_id = @userTypeId and c.is_identity = 0
                                 order by c.column_id", con))
                                 {
                                     cmd.Parameters.Add(new SqlParameter("@userTypeId", SqlDbType.Int) { Value = (int)rpcParam.UserTypeId });
@@ -327,7 +327,7 @@
                                 var row = new List<object>();
                                 for (var i = 0; i < tvpValue.Columns.Count; i++)
                                 {
-                                    if (insertValues[i] == "NULL")
+                                    if (insertValues[i] == "NULL" || insertValues[i] == "default")
                                     {
                                         row.Add(DBNull.Value);
                                     }
@@ -337,7 +337,7 @@
                                     }
                                     else
                                     {
-                                        row.Add(GetSystemValue(insertValues[i], tvpValue.Columns[i].SqlDbType));
+                                        row.Add(GetSystemValue(insertValues[i], tvpValue.Columns[i].SqlDbType));                                        
                                     }
                                 }
                                 tvpValue.Rows.Add(row);
@@ -400,9 +400,9 @@
             switch (sqlDbType)
             {
                 case SqlDbType.BigInt:
-                    return long.Parse(value);
+                    return decimal.ToInt64(decimal.Parse(value));
                 case SqlDbType.Bit:
-                    return Convert.ToBoolean(byte.Parse(value));
+                    return Convert.ToBoolean(decimal.ToByte(decimal.Parse(value)));
                 case SqlDbType.Char:
                 case SqlDbType.NChar:
                 case SqlDbType.VarChar:
@@ -423,9 +423,9 @@
                 case SqlDbType.UniqueIdentifier:
                     return Guid.Parse(value);
                 case SqlDbType.SmallInt:
-                    return short.Parse(value);
+                    return decimal.ToInt16(decimal.Parse(value));
                 case SqlDbType.TinyInt:
-                    return byte.Parse(value);
+                    return decimal.ToByte(decimal.Parse(value));
                 case SqlDbType.SmallDateTime:
                 case SqlDbType.DateTime:
                 case SqlDbType.Date:

--- a/SqlReplay.Console/Runner.cs
+++ b/SqlReplay.Console/Runner.cs
@@ -86,7 +86,7 @@
                         {
                             TransactionId = model.TransactionId,
                             TransactionState = "Commit",
-                            EventSequence = (int.Parse(model.EventSequence) + 1).ToString(),
+                            EventSequence = model.EventSequence + 1,
                             Timestamp = model.Timestamp.AddMilliseconds(100)
                         });
                     }

--- a/SqlReplay.Console/Runner.cs
+++ b/SqlReplay.Console/Runner.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using System.Linq;
-    using System.Data.SqlClient;
+    using System.Data;
 
     public class Runner
     {
@@ -28,6 +28,17 @@
             var allEvents = run.Sessions.SelectMany(s => s.Events)
                 //.Where(e => !matchCriteria.Any(mc => ((e as Rpc)?.ObjectName.Contains(mc, StringComparison.CurrentCultureIgnoreCase)).GetValueOrDefault())) //leave these out
                 .ToList();
+
+            ////Remove procedure name and parameters so proc calls with TVP variables will get executed as SQLBatch instead of RCP and get plan stored in cache
+            //foreach (var evt in allEvents)
+            //{
+            //    if (!(evt is Rpc rpc)) continue;
+            //    if (rpc.Parameters.Any(p => p.SqlDbType == SqlDbType.Structured))
+            //    {
+            //        rpc.Procedure = null;
+            //        rpc.Parameters.Clear();
+            //    }
+            //}
 
             var allDependentEvents = allEvents.Where(e => e.TransactionId != "0" && ((e is Rpc) || (e as Transaction)?.TransactionState != "Begin")).ToList();
             var allIndependentEvents = allEvents.Where(e => e.TransactionId == "0" || (e as Transaction)?.TransactionState == "Begin");

--- a/SqlReplay.Console/UserType.cs
+++ b/SqlReplay.Console/UserType.cs
@@ -1,0 +1,12 @@
+﻿namespace SqlReplay.Console
+{
+    using System;
+    using System.Collections.Generic;
+
+    [Serializable]
+    public class UserType
+    {
+        public List<UserTypeColumn> Columns { get; set; } = new List<UserTypeColumn>();
+        public List<List<object>> Rows { get; set; } = new List<List<object>>();
+    }
+}

--- a/SqlReplay.Console/UserTypeColumn.cs
+++ b/SqlReplay.Console/UserTypeColumn.cs
@@ -1,0 +1,13 @@
+﻿namespace SqlReplay.Console
+{
+    using System;
+    using System.Data;
+
+    [Serializable]
+    public class UserTypeColumn
+    {
+        public string Name { get; set; }
+        public SqlDbType SqlDbType { get; set; }
+        public int Size { get; set; }
+    }
+}


### PR DESCRIPTION
Processing proc calls with TVP variables as ADO.NET StoredProcedure call with parameters, which is sent to SQL Server as a RCP call instead of SQLBatch call when these calls are made simply as CommandText with no parameters.