### PR TITLE
Updated buckets sorting key from ddhhmm to ddHHmm to handle AM and PM events execution order.

### DIFF
--- a/SqlReplay.Console/Runner.cs
+++ b/SqlReplay.Console/Runner.cs
@@ -159,7 +159,7 @@
             var buckets = run.Sessions.GroupBy(s => 
             {
                 Event firstEvt = s.Events.First();
-                return firstEvt.Timestamp.ToString("ddhhmm") + firstEvt.Timestamp.Second / runnerSettings.BucketInterval;         
+                return firstEvt.Timestamp.ToString("ddHHmm") + firstEvt.Timestamp.Second / runnerSettings.BucketInterval;         
             })
             .OrderBy(g => g.Key)
             .Select(g => g.OrderBy(s => s.Events.First().Timestamp)


### PR DESCRIPTION
With firstEvt.Timestamp.ToString("ddhhmm"), "0801041" bucket will be processed before "0802320", but it contains later (PM) events as follows.

{10/8/2020 2:32:11 AM +00:00} -> Key == "0802320"
{10/8/2020 1:04:24 PM +00:00} -> Key == "0801041"

Changing "ddhhmm" to "ddHHmm" resolves the issue.

{10/8/2020 2:32:11 AM +00:00} -> Key == "0802320"
{10/8/2020 1:04:24 PM +00:00} -> Key == "0813041".
