### PR TITLE
Implemented timestamped exceptions logging.

### DIFF
--- a/SqlReplay.Console/EventExecutor.cs
+++ b/SqlReplay.Console/EventExecutor.cs
@@ -11,7 +11,7 @@
 
     internal class EventExecutor
     {       
-        public List<Exception> Exceptions { get; set; } = new List<Exception>();
+        public List<TimestampedException> Exceptions { get; set; } = new List<TimestampedException>();
 
         public async Task ExecuteSessionEventsAsync(DateTimeOffset eventCaptureOrigin, DateTimeOffset replayOrigin, IEnumerable<Session> sessions, string connectionString, IRunnerSettings runnerSettings)
         {
@@ -56,7 +56,7 @@
                                     }
                                     catch (Exception ex)
                                     {
-                                        this.Exceptions.Add(ex);
+                                        this.Exceptions.Add(new TimestampedException(ex));
                                     }
                                 }
                             }
@@ -95,7 +95,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    this.Exceptions.Add(ex);
+                                    this.Exceptions.Add(new TimestampedException(ex));
                                 }
                             }
                             else if (evt is BulkInsert bulkInsert)
@@ -157,7 +157,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    this.Exceptions.Add(ex);
+                                    this.Exceptions.Add(new TimestampedException(ex));
                                 }
                             }
                         }));
@@ -467,6 +467,6 @@
             {
                 throw new Exception(column.SqlDbType + " is not a supported data type.");
             }
-        }      
+        }
     }
 }

--- a/SqlReplay.Console/Program.cs
+++ b/SqlReplay.Console/Program.cs
@@ -149,7 +149,7 @@ namespace SqlReplay.Console
             using (StreamWriter writer = new StreamWriter(logFilePath, false))
             {
                 await writer.WriteLineAsync($"{runner.Exceptions.Count} exceptions captured");
-                foreach (Exception ex in runner.Exceptions)
+                foreach (var ex in runner.Exceptions)
                 {
                     await writer.WriteLineAsync(ex.ToString());
                 }
@@ -171,7 +171,7 @@ namespace SqlReplay.Console
             using (StreamWriter writer = new StreamWriter(logFilePath, false))
             {
                 await writer.WriteLineAsync($"{runner.Exceptions.Count} exceptions captured");
-                foreach (Exception ex in runner.Exceptions)
+                foreach (var ex in runner.Exceptions)
                 {
                     await writer.WriteLineAsync(ex.ToString());
                 }

--- a/SqlReplay.Console/Runner.cs
+++ b/SqlReplay.Console/Runner.cs
@@ -9,7 +9,7 @@
 
     public class Runner
     {
-        public List<Exception> Exceptions { get; set; } = new List<Exception>();
+        public List<TimestampedException> Exceptions { get; set; } = new List<TimestampedException>();
 
         public Task WarmupAsync(Run run, int durationInMinutes, string[] storedProcedureNamesToInclude)
         {

--- a/SqlReplay.Console/TimestampedException.cs
+++ b/SqlReplay.Console/TimestampedException.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace SqlReplay.Console
+{
+    [Serializable]
+    public class TimestampedException
+    {
+        public TimestampedException(Exception ex)
+        {
+            UtcTimestamp = DateTime.UtcNow;
+            Exception = ex;
+        }
+
+        public DateTime UtcTimestamp { get; private set; }
+
+        public Exception Exception { get; private set; }
+
+        public override string ToString()
+        {
+            return $"{GetTimestamp()} - {Exception}";
+        }
+
+        private string GetTimestamp()
+        {
+            return string.Format($"{UtcTimestamp:MM-dd-yyyy--HH-mm-ss}");
+        }
+    }
+}


### PR DESCRIPTION
Added {MM-dd-yyyy--HH-mm-ss} timestamp to each logged exception. This way exceptions can:

1. be correlated with server events affecting database availability, including automatic firmware upgrades on managed instances;
2. enable aggregation for the purpose of determining events duration.