### PR TITLE
Refresh fixes

### DIFF
--- a/SqlReplay.Console/EventExecutor.cs
+++ b/SqlReplay.Console/EventExecutor.cs
@@ -111,7 +111,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    this.Exceptions.Add(new TimestampedException(ex));
+                                    this.Exceptions.Add(new TimestampedException(ex, commandText));
                                 }
                             }
                             else if (evt is BulkInsert bulkInsert)
@@ -173,7 +173,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    this.Exceptions.Add(new TimestampedException(ex));
+                                    this.Exceptions.Add(new TimestampedException(ex, bulkInsert.BatchText));
                                 }
                             }
                         }));

--- a/SqlReplay.Console/EventExecutor.cs
+++ b/SqlReplay.Console/EventExecutor.cs
@@ -78,18 +78,7 @@
                             }
                             else if (evt is Rpc rpc)
                             {
-                                string commandText;
-                                CommandType commandType;
-                                if (!string.IsNullOrWhiteSpace(rpc.Procedure))
-                                {
-                                    commandText = rpc.Procedure;
-                                    commandType = CommandType.StoredProcedure;
-                                }
-                                else
-                                {
-                                    commandText = rpc.Statement;
-                                    commandType = CommandType.Text;
-                                }
+                                var rpcInterpreter = new RpcInterpreter(rpc);
                                 try
                                 {
                                     await RetryDeadlock(async () =>
@@ -97,13 +86,8 @@
                                         using (var sqlConnection = new SqlConnection(connectionString))
                                         {
                                             await sqlConnection.OpenAsync();
-                                            using (var sqlCommand = new SqlCommand(commandText, sqlConnection)
+                                            using (var sqlCommand = rpcInterpreter.GetSqlCommand(sqlConnection, runnerSettings.SqlCommandTimeout))
                                             {
-                                                CommandType = commandType,
-                                                CommandTimeout = runnerSettings.SqlCommandTimeout
-                                            })
-                                            {
-                                                SetupSqlCommandParameters(sqlCommand, rpc);
                                                 await sqlCommand.ExecuteNonQueryAsync();
                                             }
                                         }
@@ -111,7 +95,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    this.Exceptions.Add(new TimestampedException(ex, commandText));
+                                    this.Exceptions.Add(new TimestampedException(ex, rpcInterpreter.GetSqlCommandText()));
                                 }
                             }
                             else if (evt is BulkInsert bulkInsert)
@@ -219,30 +203,14 @@
                 }
                 else if (evt is Rpc rpc)
                 {
-                    string commandText;
-                    CommandType commandType;
-                    if (!string.IsNullOrWhiteSpace(rpc.Procedure))
-                    {
-                        commandText = rpc.Procedure;
-                        commandType = CommandType.StoredProcedure;
-                    }
-                    else
-                    {
-                        commandText = rpc.Statement;
-                        commandType = CommandType.Text;
-                    }
+                    var rpcInterpreter = new RpcInterpreter(rpc);
                     await RetryDeadlock(async () =>
                     {
                         using (var sqlConnection = new SqlConnection(connectionString))
                         {
                             await sqlConnection.OpenAsync();
-                            using (var sqlCommand = new SqlCommand(commandText, sqlConnection)
+                            using (var sqlCommand = rpcInterpreter.GetSqlCommand(sqlConnection, runnerSettings.SqlCommandTimeout))
                             {
-                                CommandType = commandType,
-                                CommandTimeout = runnerSettings.SqlCommandTimeout
-                            })
-                            {
-                                SetupSqlCommandParameters(sqlCommand, rpc);
                                 await sqlCommand.ExecuteNonQueryAsync();
                             }
                         }
@@ -336,127 +304,6 @@
                 return true;
             }
             return ex.InnerException != null && HasDeadlock(ex.InnerException);
-        }
-
-        private void SetupSqlCommandParameters(SqlCommand cmd, Rpc rpc)
-        {
-            foreach (var param in rpc.Parameters)
-            {
-                var sqlParam = new SqlParameter
-                {
-                    ParameterName = param.Name,
-                    SqlDbType = param.SqlDbType,
-                    Size = param.Size,
-                    Precision = param.Precision,
-                    Scale = param.Scale,
-                    Direction = param.Direction
-                };
-                if (param.SqlDbType == SqlDbType.Structured)
-                {
-                    if (param.Value != DBNull.Value)
-                    {
-                        var userType = (UserType) param.Value;
-                        if (userType.Rows.Count > 0)
-                        {
-                            var sqlMetaData = new SqlMetaData[userType.Columns.Count];
-                            for (var i = 0; i < userType.Columns.Count; i++)
-                            {
-                                var col = userType.Columns[i];
-                                switch (col.SqlDbType)
-                                {
-                                    case SqlDbType.Char:
-                                    case SqlDbType.NChar:
-                                    case SqlDbType.NVarChar:
-                                    case SqlDbType.VarChar:
-                                        sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType, col.Size);
-                                        break;
-                                    default:
-                                        sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType);
-                                        break;
-                                }
-                            }
-
-                            var tvpValue = new List<SqlDataRecord>();
-                            foreach (var row in userType.Rows)
-                            {
-                                var sqlDataRecord = new SqlDataRecord(sqlMetaData);
-                                for (var i = 0; i < sqlMetaData.Length; i++)
-                                {
-                                    switch (sqlMetaData[i].SqlDbType)
-                                    {
-                                        case SqlDbType.SmallDateTime:
-                                        case SqlDbType.DateTime:
-                                        case SqlDbType.Date:
-                                        case SqlDbType.Time:
-                                        case SqlDbType.DateTime2:
-                                            DateTime.TryParse(row[i].ToString(), out var dateTime);
-                                            sqlDataRecord.SetValue(i, dateTime);
-                                            break;
-                                        case SqlDbType.DateTimeOffset:
-                                            DateTimeOffset.TryParse(row[i].ToString(), out var dateTimeOffset);
-                                            sqlDataRecord.SetValue(i, dateTimeOffset);
-                                            break;
-                                        default:
-                                            sqlDataRecord.SetValue(i, row[i]);
-                                            break;
-                                    }
-                                }
-
-                                tvpValue.Add(sqlDataRecord);
-                            }
-                            sqlParam.Value = tvpValue;
-                        }
-                    }
-                    sqlParam.TypeName = param.TypeName;
-                }
-                else
-                {
-                    sqlParam.Value = SqlTypifyValue(param.Value, param.SqlDbType);
-                }
-                cmd.Parameters.Add(sqlParam);
-            }
-        }
-
-        /// <summary>
-        /// Converts special case input into appropriate SQL values. See Remarks.
-        /// </summary>
-        /// <param name="inputValue">The unconverted parameter value to send to SQL</param>
-        /// <param name="sqlDbType">The SQL Type of the parameter</param>
-        /// <returns>A special default value if <paramref name="inputValue"/> is "" and <paramref name="sqlDbType"/> is
-        /// SqlDbType.Int or DateTime; otherwise, <paramref name="inputValue"/></returns>
-        /// <remarks>
-        /// <para>This oddball little method is required because some of our executions pass '' (empty string) to sproc
-        /// parameters of type INT or DATETIME. In SQL-Replay, though, ADO.Net is intercepting those executions
-        /// and complaining that "" doesn't convert to an Int32.
-        /// To limit risk exposure, this method is very tightly scoped to address only these two known occurring
-        /// problems.</para>
-        /// <para>Try this fun SQL out for a demo of what kind of type wrangling SQL allows when .NET isn't
-        /// mediating:</para>
-        /// <code>
-        /// DECLARE @defaultInt INT, @emptyStringInt INT = '', @oneSpaceInt INT = ' ', @twoSpaceInt INT = '  '
-        /// DECLARE @defaultdt DATETIME, @emptyStringDt DATETIME = '', @oneSpaceDt DATETIME = ' ', @twoSpaceDt DATETIME = '  '
-        /// SELECT @defaultInt, @emptyStringInt, @oneSpaceInt, @twoSpaceInt
-        /// SELECT @defaultdt, @emptyStringDt, @oneSpaceDt, @twoSpaceDt
-        /// -- FYI conversion fails for all the following examples:
-        /// DECLARE @tabInt INT = '	'
-        /// DECLARE @tabDt DATETIME = '	'
-        /// DECLARE @newlineInt INT = '
-        /// '
-        /// DECLARE @newlineDt DATETIME = '
-        /// '
-        /// DECLARE @alphaInt INT = 'abc'
-        /// DECLARE @alphaDt DATETIME = 'abc'
-        /// </code>
-        /// </remarks>
-        private static object SqlTypifyValue(object inputValue, SqlDbType sqlDbType)
-        {
-            return sqlDbType switch
-            {
-                SqlDbType.Int when inputValue is "" => 0,
-                SqlDbType.DateTime when inputValue is "" => DateTime.Parse("1900-01-01 00:00:00.000",
-                    CultureInfo.InvariantCulture),
-                _ => inputValue
-            };
         }
 
         private DataColumn GetDataColumn(Column column)

--- a/SqlReplay.Console/Extensions.cs
+++ b/SqlReplay.Console/Extensions.cs
@@ -15,13 +15,18 @@
             char[] chars = text.ToCharArray();
             int lefts = 1;
             int rights = 0;
+            bool withinQuotes = false;
             for (int i = leftParenthesisIndex + 1; i < chars.Length; ++i)
             {
-                if (chars[i] == '(')
+                if (chars[i] == '\'')
+                {
+                    withinQuotes = !withinQuotes;
+                }
+                else if (chars[i] == '(' && !withinQuotes)
                 {
                     lefts++;
                 }
-                else if (chars[i] == ')')
+                else if (chars[i] == ')' && !withinQuotes)
                 {
                     if (++rights == lefts)
                     {

--- a/SqlReplay.Console/PreProcessor.cs
+++ b/SqlReplay.Console/PreProcessor.cs
@@ -53,7 +53,15 @@
                                 Timestamp = xevent.Timestamp
                             };
                             //Build parameters so we can replay statements as ADO.NET CommandType.StoredProcedure calls in order to avoid extra compilations of raw statement
-                            LoadParameters(con, (Rpc)evt);
+                            try
+                            {
+                                LoadParameters(con, (Rpc) evt);
+                            }
+                            catch (OverflowException)
+                            {
+                                // in the rare event that a parameter value overflows its type, it will error on execution (as it did when run in production) so we just omit it here
+                                return Task.CompletedTask;
+                            }
                         }
                         else if (xevent.Name == "sql_transaction")
                         {

--- a/SqlReplay.Console/RpcInterpreter.cs
+++ b/SqlReplay.Console/RpcInterpreter.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Globalization;
+using Microsoft.SqlServer.Server;
+
+namespace SqlReplay.Console;
+
+public class RpcInterpreter
+{
+    private readonly Rpc _rpc;
+    private readonly string _commandText;
+    private readonly CommandType _commandType;
+
+    public RpcInterpreter(Rpc rpc)
+    {
+        _rpc = rpc;
+        if (!string.IsNullOrWhiteSpace(rpc.Procedure))
+        {
+            _commandText = rpc.Procedure;
+            _commandType = CommandType.StoredProcedure;
+        }
+        else
+        {
+            _commandText = rpc.Statement;
+            _commandType = CommandType.Text;
+        }
+    }
+
+    public SqlCommand GetSqlCommand(SqlConnection conn, int timeout)
+    {
+        var cmd =  new SqlCommand(_commandText, conn)
+        {
+            CommandType = _commandType,
+            CommandTimeout = timeout
+        };
+        foreach (var param in _rpc.Parameters)
+        {
+            cmd.Parameters.Add(ParseParameter(param));
+        }
+        
+        return cmd;
+    }
+
+    public string GetSqlCommandText()
+    {
+        string query = _commandText;
+        foreach (var param in _rpc.Parameters)
+        {
+            SqlParameter sqlParam = ParseParameter(param);
+            
+            query += $" @{sqlParam.ParameterName} = {sqlParam.Value}";
+        }
+
+        return query;
+    }
+    
+    private SqlParameter ParseParameter(Parameter param)
+        {
+            var sqlParam = new SqlParameter
+            {
+                ParameterName = param.Name,
+                SqlDbType = param.SqlDbType,
+                Size = param.Size,
+                Precision = param.Precision,
+                Scale = param.Scale,
+                Direction = param.Direction
+            };
+            if (param.SqlDbType == SqlDbType.Structured)
+            {
+                if (param.Value != DBNull.Value)
+                {
+                    var userType = (UserType) param.Value;
+                    if (userType.Rows.Count > 0)
+                    {
+                        var sqlMetaData = new SqlMetaData[userType.Columns.Count];
+                        for (var i = 0; i < userType.Columns.Count; i++)
+                        {
+                            var col = userType.Columns[i];
+                            switch (col.SqlDbType)
+                            {
+                                case SqlDbType.Char:
+                                case SqlDbType.NChar:
+                                case SqlDbType.NVarChar:
+                                case SqlDbType.VarChar:
+                                    sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType, col.Size);
+                                    break;
+                                default:
+                                    sqlMetaData[i] = new SqlMetaData(col.Name, col.SqlDbType);
+                                    break;
+                            }
+                        }
+
+                        var tvpValue = new List<SqlDataRecord>();
+                        foreach (var row in userType.Rows)
+                        {
+                            var sqlDataRecord = new SqlDataRecord(sqlMetaData);
+                            for (var i = 0; i < sqlMetaData.Length; i++)
+                            {
+                                switch (sqlMetaData[i].SqlDbType)
+                                {
+                                    case SqlDbType.SmallDateTime:
+                                    case SqlDbType.DateTime:
+                                    case SqlDbType.Date:
+                                    case SqlDbType.Time:
+                                    case SqlDbType.DateTime2:
+                                        DateTime.TryParse(row[i].ToString(), out var dateTime);
+                                        sqlDataRecord.SetValue(i, dateTime);
+                                        break;
+                                    case SqlDbType.DateTimeOffset:
+                                        DateTimeOffset.TryParse(row[i].ToString(), out var dateTimeOffset);
+                                        sqlDataRecord.SetValue(i, dateTimeOffset);
+                                        break;
+                                    default:
+                                        sqlDataRecord.SetValue(i, row[i]);
+                                        break;
+                                }
+                            }
+
+                            tvpValue.Add(sqlDataRecord);
+                        }
+                        sqlParam.Value = tvpValue;
+                    }
+                }
+                sqlParam.TypeName = param.TypeName;
+            }
+            else
+            {
+                sqlParam.Value = SqlTypifyValue(param.Value, param.SqlDbType);
+            }
+
+            return sqlParam;
+        }
+    
+        /// <summary>
+        /// Converts special case input into appropriate SQL values. See Remarks.
+        /// </summary>
+        /// <param name="inputValue">The unconverted parameter value to send to SQL</param>
+        /// <param name="sqlDbType">The SQL Type of the parameter</param>
+        /// <returns>A special default value if <paramref name="inputValue"/> is "" and <paramref name="sqlDbType"/> is
+        /// SqlDbType.Int or DateTime; otherwise, <paramref name="inputValue"/></returns>
+        /// <remarks>
+        /// <para>This oddball little method is required because some of our executions pass '' (empty string) to sproc
+        /// parameters of type INT or DATETIME. In SQL-Replay, though, ADO.Net is intercepting those executions
+        /// and complaining that "" doesn't convert to an Int32.
+        /// To limit risk exposure, this method is very tightly scoped to address only these two known occurring
+        /// problems.</para>
+        /// <para>Try this fun SQL out for a demo of what kind of type wrangling SQL allows when .NET isn't
+        /// mediating:</para>
+        /// <code>
+        /// DECLARE @defaultInt INT, @emptyStringInt INT = '', @oneSpaceInt INT = ' ', @twoSpaceInt INT = '  '
+        /// DECLARE @defaultdt DATETIME, @emptyStringDt DATETIME = '', @oneSpaceDt DATETIME = ' ', @twoSpaceDt DATETIME = '  '
+        /// SELECT @defaultInt, @emptyStringInt, @oneSpaceInt, @twoSpaceInt
+        /// SELECT @defaultdt, @emptyStringDt, @oneSpaceDt, @twoSpaceDt
+        /// -- FYI conversion fails for all the following examples:
+        /// DECLARE @tabInt INT = '	'
+        /// DECLARE @tabDt DATETIME = '	'
+        /// DECLARE @newlineInt INT = '
+        /// '
+        /// DECLARE @newlineDt DATETIME = '
+        /// '
+        /// DECLARE @alphaInt INT = 'abc'
+        /// DECLARE @alphaDt DATETIME = 'abc'
+        /// </code>
+        /// </remarks>
+        private static object SqlTypifyValue(object inputValue, SqlDbType sqlDbType)
+        {
+            return sqlDbType switch
+            {
+                SqlDbType.Int when inputValue is "" => 0,
+                SqlDbType.DateTime when inputValue is "" => DateTime.Parse("1900-01-01 00:00:00.000",
+                    CultureInfo.InvariantCulture),
+                _ => inputValue
+            };
+        }
+}

--- a/SqlReplay.Console/Runner.cs
+++ b/SqlReplay.Console/Runner.cs
@@ -108,7 +108,7 @@
             if (!string.IsNullOrEmpty(eventProcedure))
             {
                 // the Procedure will be just the name of the sproc
-                return matchCriteria.Any(mc =>
+                return matchCriteria.Exists(mc =>
                     string.Equals(eventProcedure, mc, StringComparison.CurrentCultureIgnoreCase)
                 );
             }
@@ -117,7 +117,7 @@
             {
                 // Statement could have text before or after the sproc name. This isn't an exact solution because the
                 // sproc could be mentioned in non-functional code like a comment... which would be weird to include in a RPC statement.
-                return matchCriteria.Any(mc =>
+                return matchCriteria.Exists(mc =>
                     eventStatement.Contains(mc, StringComparison.CurrentCultureIgnoreCase));
             }
             return false;

--- a/SqlReplay.Console/TimestampedException.cs
+++ b/SqlReplay.Console/TimestampedException.cs
@@ -10,14 +10,25 @@ namespace SqlReplay.Console
             UtcTimestamp = DateTime.UtcNow;
             Exception = ex;
         }
+        
+        public TimestampedException(Exception ex, string commandText)
+        {
+            UtcTimestamp = DateTime.UtcNow;
+            Exception = ex;
+            CommandText = commandText;
+        }
 
         public DateTime UtcTimestamp { get; private set; }
 
         public Exception Exception { get; private set; }
+        
+        public string CommandText { get; private set; }
 
         public override string ToString()
         {
-            return $"{GetTimestamp()} - {Exception}";
+            var s = $"{GetTimestamp()} -\r\n{Exception}";
+            s += string.IsNullOrEmpty(CommandText) ? "" : $"\r\nSQL text for above error:\r\n{CommandText}";
+            return s;
         }
 
         private string GetTimestamp()


### PR DESCRIPTION
- A couple issues were discovered with the prep process:
  - If an extended event captured a call to a sproc that tried to pass an invalid integer value, the prep step would fail because it can't convert that value to the appropriate data type. 6d3a7b0 fixes this by ignoring events that meet this condition. They will just error during the run anyway.
  - If an extended event captured a call like `exec sp_something @param='or (another'`, the prep step would fail because the left parentheses would be counted as code. 527640a fixes this by omitting parentheses inside single quotes.
- The changes to EventExecutor and TimestampedException, and addition of RpcInterpreter, add a rough version of the SQL command text to the error log to aid in diagnosing failed RPCs during a run.
- The change to Runner enhances the excluded sproc filter. Now a run filters out RPC events by the contents of the `Statement` and `Procedure` rather than just the `Procedure`.